### PR TITLE
Bugfix/solve na n when radius too small

### DIFF
--- a/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
+++ b/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
@@ -61,6 +61,9 @@ public struct ArchimedeanSpiral {
 //        let r = (radius*2.0 < d) ? d/2.0 : radius
         
         let θ = acos(1.0 - pow(d/radius, 2)*0.5)
+        if θ.isNaN {
+            debugPrint("NaN of radius:\(radius)")
+        }
         return CGAngle.radians(θ)
     }
 }

--- a/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
+++ b/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
@@ -58,9 +58,9 @@ public struct ArchimedeanSpiral {
         // Note: the range of acos should be -1...1
         // It means 1.0 - pow(d/radius, 2)*0.5 should be in range -1...1
         // This statements ensure the initial radius located in the range.
-//        let r = (radius*2.0 < d) ? d/2.0 : radius
+        let r = (radius*2.0 < d) ? d/2.0 : radius
         
-        let θ = acos(1.0 - pow(d/radius, 2)*0.5)
+        let θ = acos(1.0 - pow(d/r, 2)*0.5)
         if θ.isNaN {
             debugPrint("NaN of radius:\(radius)")
         }

--- a/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
+++ b/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
@@ -29,6 +29,13 @@ public struct ArchimedeanSpiral {
         let a = innerRadius
         let b = 0.5*radiusSpacing/CGFloat.pi
         var radius = a + b*angle.radians
+        
+        // Note: the range of acos should be -1...1
+        // It means 1.0 - pow(d/radius, 2)*0.5 should be in range -1...1
+        // This statements ensure the initial radius located in the range.
+        if radius*2.0 < self.radiusSpacing {
+            radius = self.radiusSpacing/2.0
+        }
         var points: [CGPolarPoint] = [CGPolarPoint(radius: radius, angle: start)]
         for _ in 1..<num {
             let delta = approxRadian(radius: radius)
@@ -45,6 +52,7 @@ public struct ArchimedeanSpiral {
     // since r1 ≅ r2, use r1 replace r2
     // cosθ = (2r1^2 - d^2)/2r1^2 = 1 - 0.5*(d/r1)^2
     // θ = acos(1 - 0.5*(d/r1)^2)
+    
     private func approxRadian(radius: CGFloat) -> CGAngle {
         let d = self.spacing
         let θ = acos(1.0 - pow(d/radius, 2)*0.5)

--- a/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
+++ b/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
@@ -55,7 +55,12 @@ public struct ArchimedeanSpiral {
     
     private func approxRadian(radius: CGFloat) -> CGAngle {
         let d = self.spacing
-        let θ = acos(1.0 - pow(d/radius, 2)*0.5)
+        // Note: the range of acos should be -1...1
+        // It means 1.0 - pow(d/radius, 2)*0.5 should be in range -1...1
+        // This statements ensure the initial radius located in the range.
+        let r = (radius*2.0 < d) ? d/2.0 : radius
+        
+        let θ = acos(1.0 - pow(d/r, 2)*0.5)
         return CGAngle.radians(θ)
     }
 }

--- a/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
+++ b/Sources/ArchimedeanSpiral/ArchimedeanSpiral.swift
@@ -33,8 +33,8 @@ public struct ArchimedeanSpiral {
         // Note: the range of acos should be -1...1
         // It means 1.0 - pow(d/radius, 2)*0.5 should be in range -1...1
         // This statements ensure the initial radius located in the range.
-        if radius*2.0 < self.radiusSpacing {
-            radius = self.radiusSpacing/2.0
+        if radius*2.0 < self.spacing {
+            radius = self.spacing/2.0
         }
         var points: [CGPolarPoint] = [CGPolarPoint(radius: radius, angle: start)]
         for _ in 1..<num {
@@ -58,9 +58,9 @@ public struct ArchimedeanSpiral {
         // Note: the range of acos should be -1...1
         // It means 1.0 - pow(d/radius, 2)*0.5 should be in range -1...1
         // This statements ensure the initial radius located in the range.
-        let r = (radius*2.0 < d) ? d/2.0 : radius
+//        let r = (radius*2.0 < d) ? d/2.0 : radius
         
-        let θ = acos(1.0 - pow(d/r, 2)*0.5)
+        let θ = acos(1.0 - pow(d/radius, 2)*0.5)
         return CGAngle.radians(θ)
     }
 }


### PR DESCRIPTION
When gap up to twice of inner radius, the result of approxRadian would be NaN.
It's a geometric limitation of points on the circle path.
To avoid this issue, check input radius before calculate approximate radians between two points.